### PR TITLE
fix: OpenAPI仕様はrequired配列エラーを修正

### DIFF
--- a/shared/api-specs/mcp-api.yaml
+++ b/shared/api-specs/mcp-api.yaml
@@ -802,7 +802,6 @@ components:
           type: boolean
           default: true
           description: 安全チェック実行
-      required: []
 
     MoveCommand:
       type: object
@@ -867,7 +866,6 @@ components:
         metadata:
           type: object
           description: 追加メタデータ
-      required: []
 
     StreamingCommand:
       type: object


### PR DESCRIPTION
OpenAPI 3.0.3仕様ではrequiredフィールドに空の配列を設定できないため、TakeoffCommandとPhotoCommandスキーマから空のrequired配列を削除しました。

Fixes #47

Generated with [Claude Code](https://claude.ai/code)