### PR TITLE
fix: OpenAPI仕様のTrainingParamsスキーマから空のrequired配列を削除

### DIFF
--- a/shared/api-specs/backend-api.yaml
+++ b/shared/api-specs/backend-api.yaml
@@ -977,7 +977,6 @@ components:
           maximum: 0.5
           default: 0.2
           description: 検証データ分割比率
-      required: []
 
     TrainingJob:
       type: object


### PR DESCRIPTION
OpenAPI 3.0.3仕様ではrequiredフィールドに空の配列を設定できないため、TrainingParamsスキーマから空のrequired配列を削除しました。

Fixes #47

Generated with [Claude Code](https://claude.ai/code)