### PR TITLE
Phase 2: MCP設定とドキュメント実装

### DIFF
--- a/mcp-server/MCP_SETUP.md
+++ b/mcp-server/MCP_SETUP.md
@@ -1,0 +1,158 @@
+# MCP ドローン制御システム クイックセットアップ
+
+このドキュメントは、MCPドローン制御システムを各MCPホストで素早く設定するためのクイックガイドです。
+
+## 🚀 クイックスタート
+
+### 1. 前提条件の確認
+
+```bash
+# Python バージョン確認
+python --version  # 3.9以上が必要
+
+# 依存関係のインストール
+pip install -r requirements.txt
+
+# 設定検証スクリプトの実行
+python validate_mcp_config.py
+```
+
+### 2. MCPサーバーの動作確認
+
+```bash
+# MCPサーバーのテスト
+python test_mcp_server.py
+
+# 実際の起動テスト
+python src/mcp_main.py
+```
+
+### 3. 設定ファイルの準備
+
+設定検証スクリプトを実行すると、各MCPホスト用の設定ファイルが自動生成されます：
+
+- `claude_desktop_config.json` - Claude Desktop用
+- `vscode_settings.json` - VS Code用
+- `mcp_config.json` - 汎用設定
+
+## 📋 各MCPホストでの設定
+
+### Claude Desktop
+
+1. 設定ファイルの場所を確認：
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Linux**: `~/.config/claude/claude_desktop_config.json`
+
+2. 生成された `claude_desktop_config.json` の内容を設定ファイルに追加
+
+3. Claude Desktop を再起動
+
+### VS Code
+
+1. プロジェクトの `.vscode/settings.json` に `vscode_settings.json` の内容を追加
+
+2. VS Code を再起動
+
+### Claude Code
+
+1. 設定ファイルの場所：
+   - **Windows**: `%APPDATA%\Claude Code\mcp_config.json`
+   - **macOS**: `~/Library/Application Support/Claude Code/mcp_config.json`
+   - **Linux**: `~/.config/claude-code/mcp_config.json`
+
+2. 生成された `mcp_config.json` の内容を設定ファイルに追加
+
+### Dify
+
+1. Dify管理画面で「プラグイン」→「MCPプラグイン」を選択
+
+2. 以下の情報を入力：
+   - **名前**: `MFG Drone MCP Server`
+   - **コマンド**: `python`
+   - **引数**: `[絶対パス]/src/mcp_main.py`
+   - **環境変数**: `PYTHONPATH=[絶対パス]`
+
+## 🔧 利用可能なコマンド
+
+MCPサーバーが正常に設定されると、以下のコマンドが利用可能になります：
+
+### 基本操作
+```
+ドローンに接続してください
+ドローンを離陸させてください
+右に50センチ移動してください
+時計回りに90度回転してください
+写真を撮ってください
+ドローンを着陸させてください
+```
+
+### 状態確認
+```
+ドローンの状態を確認してください
+利用可能なドローンを表示してください
+システムの状態を確認してください
+```
+
+### 緊急時
+```
+緊急停止してください
+```
+
+## 🛠️ トラブルシューティング
+
+### よくある問題
+
+1. **MCPサーバーが起動しない**
+   ```bash
+   # ログを確認
+   python src/mcp_main.py
+   
+   # 依存関係を再インストール
+   pip install --force-reinstall -r requirements.txt
+   ```
+
+2. **パスエラー**
+   ```bash
+   # 絶対パスを使用
+   python validate_mcp_config.py  # サンプル設定を再生成
+   ```
+
+3. **権限エラー**
+   ```bash
+   # 実行権限を付与
+   chmod +x src/mcp_main.py
+   ```
+
+### ログの確認
+
+```bash
+# デバッグモードで実行
+export LOG_LEVEL=DEBUG
+python src/mcp_main.py
+
+# ログファイルの確認
+tail -f /tmp/mcp_server.log
+```
+
+## 📚 詳細ドキュメント
+
+より詳細な設定手順や使用方法については、以下のドキュメントを参照してください：
+
+- [setup.md](./docs/setup.md) - 詳細なセットアップガイド
+- [FAQ.md](./docs/FAQ.md) - よくある質問
+- [command_reference.md](./docs/command_reference.md) - コマンドリファレンス
+- [error_reference.md](./docs/error_reference.md) - エラーリファレンス
+
+## 🤝 サポート
+
+問題が発生した場合は、以下のリソースを利用してください：
+
+- [GitHub Issues](https://github.com/coolerking/mfg_drone_by_claudecode/issues)
+- [プロジェクトWiki](https://github.com/coolerking/mfg_drone_by_claudecode/wiki)
+- [FAQ](./docs/FAQ.md)
+
+---
+
+**最終更新**: 2025-07-15  
+**バージョン**: 1.0.0

--- a/mcp-server/docs/setup.md
+++ b/mcp-server/docs/setup.md
@@ -1,0 +1,420 @@
+# MCP ドローン制御システム セットアップガイド
+
+このドキュメントでは、MCP（Model Context Protocol）ドローン制御システムを各MCPホストに登録する方法を説明します。
+
+## 目次
+
+1. [概要](#概要)
+2. [前提条件](#前提条件)
+3. [Claude Desktop での設定](#claude-desktop-での設定)
+4. [Visual Studio Code での設定](#visual-studio-code-での設定)
+5. [Claude Code での設定](#claude-code-での設定)
+6. [Dify での設定](#dify-での設定)
+7. [トラブルシューティング](#トラブルシューティング)
+8. [利用可能なツール](#利用可能なツール)
+9. [利用可能なリソース](#利用可能なリソース)
+
+## 概要
+
+このMCPサーバーは、自然言語でドローンを制御できる包括的なシステムです。以下の機能を提供します：
+
+- **ドローン制御**: 離陸、着陸、移動、回転
+- **カメラ操作**: 写真撮影、ビデオ録画
+- **自然言語処理**: 日本語コマンドの理解・実行
+- **システム監視**: ドローン状態の確認
+- **緊急停止**: 安全機能
+
+## 前提条件
+
+### システム要件
+
+- Python 3.9以上
+- MCP SDK 1.0.0以上
+- 必要なPythonパッケージ（requirements.txtを参照）
+
+### インストール
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/coolerking/mfg_drone_by_claudecode.git
+cd mfg_drone_by_claudecode/mcp-server
+
+# 依存関係をインストール
+pip install -r requirements.txt
+
+# MCPサーバーをテスト
+python test_mcp_server.py
+```
+
+### MCPサーバーの起動確認
+
+```bash
+# MCPモードでサーバーを起動
+python start_mcp_server_unified.py --mode mcp
+
+# または
+python src/mcp_main.py
+```
+
+## Claude Desktop での設定
+
+### 1. 設定ファイルの場所
+
+Claude Desktopの設定ファイルは以下の場所にあります：
+
+**Windows:**
+```
+%APPDATA%\Claude\claude_desktop_config.json
+```
+
+**macOS:**
+```
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+**Linux:**
+```
+~/.config/claude/claude_desktop_config.json
+```
+
+### 2. 設定の追加
+
+設定ファイルに以下を追加します：
+
+```json
+{
+  "mcpServers": {
+    "mfg-drone-mcp-server": {
+      "command": "python",
+      "args": [
+        "/path/to/mfg_drone_by_claudecode/mcp-server/src/mcp_main.py"
+      ],
+      "env": {
+        "PYTHONPATH": "/path/to/mfg_drone_by_claudecode/mcp-server",
+        "DRONE_MODE": "auto",
+        "LOG_LEVEL": "INFO"
+      }
+    }
+  }
+}
+```
+
+### 3. Claude Desktopの再起動
+
+設定を保存後、Claude Desktopを再起動してください。
+
+### 4. 動作確認
+
+Claude Desktopで以下のコマンドを試してください：
+
+```
+利用可能なドローンツールを表示してください
+```
+
+## Visual Studio Code での設定
+
+### 1. MCP拡張機能のインストール
+
+VS Code Marketplaceから「MCP」拡張機能をインストールします。
+
+### 2. ワークスペース設定
+
+プロジェクトの `.vscode/settings.json` に以下を追加：
+
+```json
+{
+  "mcp.servers": {
+    "mfg-drone-mcp-server": {
+      "command": "python",
+      "args": [
+        "/path/to/mfg_drone_by_claudecode/mcp-server/src/mcp_main.py"
+      ],
+      "env": {
+        "PYTHONPATH": "/path/to/mfg_drone_by_claudecode/mcp-server",
+        "DRONE_MODE": "auto"
+      }
+    }
+  }
+}
+```
+
+### 3. グローバル設定（オプション）
+
+VS Codeのグローバル設定でも同様に設定できます：
+
+1. `Ctrl+Shift+P` (Windows/Linux) または `Cmd+Shift+P` (macOS)
+2. 「Preferences: Open Settings (JSON)」を選択
+3. 上記の設定を追加
+
+### 4. 動作確認
+
+VS Codeのコマンドパレットで「MCP: Connect to Server」を選択し、「mfg-drone-mcp-server」を選択してください。
+
+## Claude Code での設定
+
+### 1. 設定ファイルの場所
+
+Claude Codeの設定ファイルは以下の場所にあります：
+
+**Windows:**
+```
+%APPDATA%\Claude Code\mcp_config.json
+```
+
+**macOS:**
+```
+~/Library/Application Support/Claude Code/mcp_config.json
+```
+
+**Linux:**
+```
+~/.config/claude-code/mcp_config.json
+```
+
+### 2. 設定の追加
+
+設定ファイルに以下を追加します：
+
+```json
+{
+  "mcpServers": {
+    "mfg-drone-mcp-server": {
+      "command": "python",
+      "args": [
+        "/path/to/mfg_drone_by_claudecode/mcp-server/src/mcp_main.py"
+      ],
+      "env": {
+        "PYTHONPATH": "/path/to/mfg_drone_by_claudecode/mcp-server",
+        "DRONE_MODE": "auto",
+        "LOG_LEVEL": "INFO"
+      }
+    }
+  }
+}
+```
+
+### 3. 環境変数の設定（オプション）
+
+```bash
+# 環境変数でMCPサーバーを指定
+export CLAUDE_MCP_SERVER_CONFIG="/path/to/mfg_drone_by_claudecode/mcp-server/mcp_config.json"
+```
+
+### 4. 動作確認
+
+Claude Codeで以下のコマンドを実行：
+
+```bash
+claude-code --mcp-server mfg-drone-mcp-server
+```
+
+## Dify での設定
+
+### 1. プラグイン設定
+
+Difyの管理画面で「プラグイン」→「MCPプラグイン」を選択します。
+
+### 2. MCPサーバーの登録
+
+以下の情報を入力します：
+
+- **名前**: `MFG Drone MCP Server`
+- **識別子**: `mfg-drone-mcp-server`
+- **コマンド**: `python`
+- **引数**: `/path/to/mfg_drone_by_claudecode/mcp-server/src/mcp_main.py`
+- **環境変数**:
+  ```
+  PYTHONPATH=/path/to/mfg_drone_by_claudecode/mcp-server
+  DRONE_MODE=auto
+  LOG_LEVEL=INFO
+  ```
+
+### 3. 接続テスト
+
+「接続テスト」ボタンをクリックして、MCPサーバーとの接続を確認します。
+
+### 4. ワークフローでの使用
+
+Difyのワークフローで「MCP Tool」ノードを追加し、登録したMCPサーバーを選択してください。
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+#### 1. MCPサーバーが起動しない
+
+**症状**: MCPサーバーが起動しない、または接続できない
+
+**解決方法**:
+```bash
+# 依存関係を確認
+pip install -r requirements.txt
+
+# 手動でテスト
+python test_mcp_server.py
+
+# ログを確認
+tail -f /tmp/mcp_server.log
+```
+
+#### 2. パスが見つからない
+
+**症状**: "No such file or directory" エラー
+
+**解決方法**:
+- 設定ファイルのパスを絶対パスに変更
+- PYTHONPATHが正しく設定されているか確認
+
+#### 3. 権限エラー
+
+**症状**: Permission denied エラー
+
+**解決方法**:
+```bash
+# 実行権限を付与
+chmod +x src/mcp_main.py
+
+# 仮想環境を使用
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+#### 4. ドローン接続エラー
+
+**症状**: ドローンに接続できない
+
+**解決方法**:
+```bash
+# シミュレーションモードで起動
+export DRONE_MODE=simulation
+python src/mcp_main.py
+
+# 実機検出を試す
+export DRONE_MODE=auto
+python src/mcp_main.py
+```
+
+### ログの確認
+
+MCPサーバーのログは以下の場所に保存されます：
+
+```bash
+# ログファイルの場所
+tail -f /tmp/mcp_server.log
+
+# デバッグレベルでログを出力
+export LOG_LEVEL=DEBUG
+python src/mcp_main.py
+```
+
+## 利用可能なツール
+
+このMCPサーバーでは以下のツールが利用可能です：
+
+### 1. connect_drone
+**説明**: ドローンに接続します
+**パラメータ**: 
+- `drone_type`: ドローンの種類（"tello"、"simulation"）
+
+### 2. takeoff_drone
+**説明**: ドローンを離陸させます
+**パラメータ**: 
+- `drone_id`: ドローンのID
+
+### 3. land_drone
+**説明**: ドローンを着陸させます
+**パラメータ**: 
+- `drone_id`: ドローンのID
+
+### 4. move_drone
+**説明**: ドローンを移動させます
+**パラメータ**: 
+- `drone_id`: ドローンのID
+- `direction`: 移動方向（forward、backward、left、right、up、down）
+- `distance`: 移動距離（1-500cm）
+- `speed`: 移動速度（10-100cm/s）
+
+### 5. rotate_drone
+**説明**: ドローンを回転させます
+**パラメータ**: 
+- `drone_id`: ドローンのID
+- `direction`: 回転方向（clockwise、counterclockwise）
+- `angle`: 回転角度（1-360度）
+
+### 6. take_photo
+**説明**: ドローンで写真を撮影します
+**パラメータ**: 
+- `drone_id`: ドローンのID
+- `filename`: 保存するファイル名（オプション）
+
+### 7. execute_natural_language_command
+**説明**: 自然言語コマンドを実行します
+**パラメータ**: 
+- `command`: 日本語のコマンド
+- `drone_id`: ドローンのID（オプション）
+
+### 8. emergency_stop
+**説明**: 緊急停止を実行します
+**パラメータ**: 
+- `drone_id`: ドローンのID
+
+## 利用可能なリソース
+
+### 1. drone://available
+**説明**: 利用可能なドローンの一覧を取得
+
+### 2. drone://status/{drone_id}
+**説明**: 指定されたドローンの状態を取得
+
+### 3. system://status
+**説明**: システム全体の状態を取得
+
+## 使用例
+
+### 基本的な使用方法
+
+```
+# ドローンに接続
+ドローンに接続してください
+
+# 離陸
+ドローンを離陸させてください
+
+# 移動
+右に50センチ移動してください
+
+# 写真撮影
+写真を撮ってください
+
+# 着陸
+ドローンを着陸させてください
+```
+
+### 高度な使用方法
+
+```
+# 複雑なコマンド
+ドローンを前方に100センチ移動させて、右に90度回転し、写真を撮影してください
+
+# 状態確認
+ドローンの状態を確認してください
+
+# 緊急停止
+緊急停止してください
+```
+
+## サポート
+
+問題が発生した場合は、以下のリソースを参照してください：
+
+- **FAQ**: [FAQ.md](./FAQ.md)
+- **エラーリファレンス**: [error_reference.md](./error_reference.md)
+- **コマンドリファレンス**: [command_reference.md](./command_reference.md)
+- **GitHub Issues**: [プロジェクトのIssues](https://github.com/coolerking/mfg_drone_by_claudecode/issues)
+
+---
+
+**更新日**: 2025-07-15  
+**バージョン**: 1.0.0  
+**作成者**: MFG Drone Team

--- a/mcp-server/mcp_config.json
+++ b/mcp-server/mcp_config.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "mfg-drone-mcp-server": {
+      "command": "python",
+      "args": [
+        "src/mcp_main.py"
+      ],
+      "env": {
+        "PYTHONPATH": ".",
+        "DRONE_MODE": "auto",
+        "TELLO_AUTO_DETECT": "true",
+        "LOG_LEVEL": "INFO"
+      }
+    }
+  }
+}

--- a/mcp-server/validate_mcp_config.py
+++ b/mcp-server/validate_mcp_config.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+MCP設定検証スクリプト
+MCPサーバーの設定と動作を確認するためのユーティリティ
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+def validate_python_environment():
+    """Python環境の検証"""
+    print("🔍 Python環境を確認中...")
+    
+    # Pythonバージョン確認
+    python_version = sys.version_info
+    print(f"Python バージョン: {python_version.major}.{python_version.minor}.{python_version.micro}")
+    
+    if python_version < (3, 9):
+        print("❌ Python 3.9以上が必要です")
+        return False
+    
+    # 必要なパッケージの確認
+    required_packages = [
+        "mcp",
+        "fastapi",
+        "uvicorn",
+        "pydantic",
+        "httpx",
+        "structlog"
+    ]
+    
+    missing_packages = []
+    for package in required_packages:
+        try:
+            __import__(package)
+            print(f"✅ {package} - インストール済み")
+        except ImportError:
+            missing_packages.append(package)
+            print(f"❌ {package} - 未インストール")
+    
+    if missing_packages:
+        print(f"\n以下のパッケージをインストールしてください:")
+        print(f"pip install {' '.join(missing_packages)}")
+        return False
+    
+    return True
+
+def validate_mcp_config(config_path: str = "mcp_config.json") -> Optional[Dict[str, Any]]:
+    """MCP設定ファイルの検証"""
+    print(f"\n🔍 MCP設定ファイルを確認中: {config_path}")
+    
+    if not os.path.exists(config_path):
+        print(f"❌ 設定ファイルが見つかりません: {config_path}")
+        return None
+    
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+        
+        print("✅ 設定ファイルの読み込み成功")
+        
+        # 基本構造の確認
+        if "mcpServers" not in config:
+            print("❌ 'mcpServers' セクションが見つかりません")
+            return None
+        
+        servers = config["mcpServers"]
+        if not servers:
+            print("❌ MCPサーバーが設定されていません")
+            return None
+        
+        # 各サーバー設定の確認
+        for server_name, server_config in servers.items():
+            print(f"\n📋 サーバー設定確認: {server_name}")
+            
+            # 必須フィールドの確認
+            if "command" not in server_config:
+                print(f"❌ 'command' フィールドが見つかりません")
+                return None
+            
+            if "args" not in server_config:
+                print(f"❌ 'args' フィールドが見つかりません")
+                return None
+            
+            command = server_config["command"]
+            args = server_config["args"]
+            
+            print(f"   コマンド: {command}")
+            print(f"   引数: {args}")
+            
+            # メインスクリプトの存在確認
+            if args and len(args) > 0:
+                main_script = args[0]
+                if not os.path.exists(main_script):
+                    print(f"❌ メインスクリプトが見つかりません: {main_script}")
+                    return None
+                print(f"✅ メインスクリプト確認: {main_script}")
+            
+            # 環境変数の確認
+            if "env" in server_config:
+                env_vars = server_config["env"]
+                print(f"   環境変数: {env_vars}")
+        
+        return config
+        
+    except json.JSONDecodeError as e:
+        print(f"❌ 設定ファイルのJSONパースエラー: {e}")
+        return None
+    except Exception as e:
+        print(f"❌ 設定ファイルの読み込みエラー: {e}")
+        return None
+
+def test_mcp_server():
+    """MCPサーバーのテスト実行"""
+    print("\n🔍 MCPサーバーのテスト実行中...")
+    
+    try:
+        # テストスクリプトの実行
+        result = subprocess.run(
+            [sys.executable, "test_mcp_server.py"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        
+        if result.returncode == 0:
+            print("✅ MCPサーバーのテスト成功")
+            print("テスト出力:")
+            print(result.stdout)
+            return True
+        else:
+            print("❌ MCPサーバーのテスト失敗")
+            print("エラー出力:")
+            print(result.stderr)
+            return False
+    
+    except subprocess.TimeoutExpired:
+        print("❌ MCPサーバーのテストがタイムアウトしました")
+        return False
+    except FileNotFoundError:
+        print("❌ test_mcp_server.py が見つかりません")
+        return False
+    except Exception as e:
+        print(f"❌ MCPサーバーのテスト中にエラーが発生: {e}")
+        return False
+
+def generate_sample_configs():
+    """サンプル設定の生成"""
+    print("\n📝 サンプル設定を生成中...")
+    
+    # 現在のディレクトリの絶対パス
+    current_dir = os.path.abspath(".")
+    main_script = os.path.join(current_dir, "src", "mcp_main.py")
+    
+    # Claude Desktop用設定
+    claude_desktop_config = {
+        "mcpServers": {
+            "mfg-drone-mcp-server": {
+                "command": "python",
+                "args": [main_script],
+                "env": {
+                    "PYTHONPATH": current_dir,
+                    "DRONE_MODE": "auto",
+                    "TELLO_AUTO_DETECT": "true",
+                    "LOG_LEVEL": "INFO"
+                }
+            }
+        }
+    }
+    
+    # VS Code用設定
+    vscode_config = {
+        "mcp.servers": {
+            "mfg-drone-mcp-server": {
+                "command": "python",
+                "args": [main_script],
+                "env": {
+                    "PYTHONPATH": current_dir,
+                    "DRONE_MODE": "auto"
+                }
+            }
+        }
+    }
+    
+    # 設定ファイルを生成
+    with open("claude_desktop_config.json", "w", encoding="utf-8") as f:
+        json.dump(claude_desktop_config, f, indent=2, ensure_ascii=False)
+    
+    with open("vscode_settings.json", "w", encoding="utf-8") as f:
+        json.dump(vscode_config, f, indent=2, ensure_ascii=False)
+    
+    print("✅ サンプル設定ファイルを生成しました:")
+    print("   - claude_desktop_config.json (Claude Desktop用)")
+    print("   - vscode_settings.json (VS Code用)")
+    
+    # 設定手順の表示
+    print("\n📋 設定手順:")
+    print("1. Claude Desktop:")
+    print("   - 設定ファイルの場所を確認")
+    print("   - claude_desktop_config.json の内容を設定ファイルに追加")
+    print("   - Claude Desktop を再起動")
+    
+    print("\n2. VS Code:")
+    print("   - .vscode/settings.json にvscode_settings.json の内容を追加")
+    print("   - VS Code を再起動")
+
+def main():
+    """メイン関数"""
+    print("🚁 MCP ドローン制御システム 設定検証ツール")
+    print("=" * 50)
+    
+    # Python環境の確認
+    if not validate_python_environment():
+        print("\n❌ Python環境の確認に失敗しました")
+        return 1
+    
+    # MCP設定の確認
+    config = validate_mcp_config()
+    if not config:
+        print("\n⚠️ MCP設定ファイルの問題を検出しました")
+        print("サンプル設定を生成します...")
+        generate_sample_configs()
+        return 1
+    
+    # MCPサーバーのテスト
+    if not test_mcp_server():
+        print("\n❌ MCPサーバーのテストに失敗しました")
+        return 1
+    
+    print("\n✅ すべての確認が完了しました！")
+    print("MCPサーバーは正常に動作します。")
+    
+    # 次のステップの提案
+    print("\n📋 次のステップ:")
+    print("1. 各MCPホストの設定ファイルを更新")
+    print("2. MCPホストを再起動")
+    print("3. ドローン制御コマンドをテスト")
+    print("4. 詳細な使用方法は docs/setup.md を参照")
+    
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Phase 2: MCP設定とドキュメントを実装しました。

✅ 実装成果物:
- docs/setup.md: 全MCPホスト対応の完全なセットアップガイド
- MCP_SETUP.md: クイックスタートガイド
- mcp_config.json: 汎用MCP設定ファイル
- validate_mcp_config.py: 設定検証・テストツール

✅ 対応ホスト:
- Claude Desktop
- Visual Studio Code
- Claude Code
- Dify

✅ 機能:
- 8つのMCPツール (ドローン制御、写真撮影、自然言語処理等)
- 3つのMCPリソース (ドローン状態、システム状態)
- 自動設定ファイル生成
- 包括的なトラブルシューティング
- 日本語完全対応

✅ 次のステップ:
- Phase 3: ハイブリッド運用
- Phase 4: 包括的ドキュメント更新

🤖 Generated with [Claude Code](https://claude.ai/code)

残タスクあり： #80