### PR TITLE
Phase 4: MCPサーバからAPIサーバ機能を除去

### DIFF
--- a/mcp-server/config/settings.py
+++ b/mcp-server/config/settings.py
@@ -11,15 +11,10 @@ import logging
 class Settings(BaseSettings):
     """Application settings with enhanced security configuration"""
     
-    # API Settings
-    api_title: str = "MCP Drone Control Server"
-    api_version: str = "1.0.0"
-    api_description: str = "MCP (Model Context Protocol) server for drone control"
-    
-    # Server Settings
-    host: str = Field(default="localhost", env="MCP_HOST")
-    port: int = Field(default=8001, env="MCP_PORT")
-    debug: bool = Field(default=False, env="MCP_DEBUG")
+    # MCP Server Settings
+    server_title: str = "MCP Drone Control Server"
+    server_version: str = "1.0.0"
+    server_description: str = "MCP (Model Context Protocol) server for drone control"
     
     # Environment Type
     environment: str = Field(default="development", env="ENVIRONMENT")
@@ -47,38 +42,7 @@ class Settings(BaseSettings):
     allowed_ips: List[str] = Field(default=[], env="ALLOWED_IPS")
     blocked_ips: List[str] = Field(default=[], env="BLOCKED_IPS")
     
-    # SSL/TLS Settings
-    ssl_enabled: bool = Field(default=False, env="SSL_ENABLED")
-    ssl_cert_path: Optional[str] = Field(default=None, env="SSL_CERT_PATH")
-    ssl_key_path: Optional[str] = Field(default=None, env="SSL_KEY_PATH")
-    ssl_ca_path: Optional[str] = Field(default=None, env="SSL_CA_PATH")
-    force_https: bool = Field(default=False, env="FORCE_HTTPS")
-    
-    # CORS Settings
-    cors_enabled: bool = Field(default=True, env="CORS_ENABLED")
-    allowed_origins: List[str] = Field(default=["*"], env="ALLOWED_ORIGINS")
-    cors_allow_credentials: bool = Field(default=True, env="CORS_ALLOW_CREDENTIALS")
-    cors_max_age: int = Field(default=86400, env="CORS_MAX_AGE")
-    
-    # Security Headers
-    security_headers_enabled: bool = Field(default=True, env="SECURITY_HEADERS_ENABLED")
-    content_security_policy: str = Field(
-        default="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'",
-        env="CONTENT_SECURITY_POLICY"
-    )
-    x_frame_options: str = Field(default="DENY", env="X_FRAME_OPTIONS")
-    x_content_type_options: str = Field(default="nosniff", env="X_CONTENT_TYPE_OPTIONS")
-    referrer_policy: str = Field(default="strict-origin-when-cross-origin", env="REFERRER_POLICY")
-    
-    # Rate Limiting
-    rate_limit_enabled: bool = Field(default=True, env="RATE_LIMIT_ENABLED")
-    rate_limit_requests_per_minute: int = Field(default=60, env="RATE_LIMIT_REQUESTS_PER_MINUTE")
-    rate_limit_requests_per_hour: int = Field(default=1000, env="RATE_LIMIT_REQUESTS_PER_HOUR")
-    rate_limit_burst_size: int = Field(default=10, env="RATE_LIMIT_BURST_SIZE")
-    
-    # Trusted Hosts
-    trusted_hosts: List[str] = Field(default=["localhost", "127.0.0.1"], env="TRUSTED_HOSTS")
-    trusted_hosts_enabled: bool = Field(default=True, env="TRUSTED_HOSTS_ENABLED")
+    # HTTP server related settings removed for pure MCP server
     
     # Natural Language Processing Settings
     default_language: str = Field(default="ja", env="DEFAULT_LANGUAGE")
@@ -94,34 +58,12 @@ class Settings(BaseSettings):
     audit_log_file: Optional[str] = Field(default=None, env="AUDIT_LOG_FILE")
     audit_log_retention_days: int = Field(default=30, env="AUDIT_LOG_RETENTION_DAYS")
     
-    # Performance Settings
-    max_concurrent_requests: int = Field(default=100, env="MAX_CONCURRENT_REQUESTS")
-    request_timeout: int = Field(default=60, env="REQUEST_TIMEOUT")
-    
-    # Hybrid System Settings
-    hybrid_monitor_interval: int = Field(default=30, env="HYBRID_MONITOR_INTERVAL")
-    hybrid_max_metrics_history: int = Field(default=100, env="HYBRID_MAX_METRICS_HISTORY")
-    hybrid_startup_timeout: float = Field(default=30.0, env="HYBRID_STARTUP_TIMEOUT")
-    hybrid_shutdown_timeout: float = Field(default=15.0, env="HYBRID_SHUTDOWN_TIMEOUT")
-    hybrid_health_check_interval: float = Field(default=10.0, env="HYBRID_HEALTH_CHECK_INTERVAL")
-    hybrid_max_restart_attempts: int = Field(default=3, env="HYBRID_MAX_RESTART_ATTEMPTS")
-    
-    # Hybrid Alert Thresholds
-    hybrid_cpu_threshold: float = Field(default=80.0, env="HYBRID_CPU_THRESHOLD")
-    hybrid_memory_threshold: float = Field(default=85.0, env="HYBRID_MEMORY_THRESHOLD")
-    hybrid_disk_threshold: float = Field(default=90.0, env="HYBRID_DISK_THRESHOLD")
-    hybrid_response_time_threshold: float = Field(default=5.0, env="HYBRID_RESPONSE_TIME_THRESHOLD")
-    hybrid_error_rate_threshold: float = Field(default=5.0, env="HYBRID_ERROR_RATE_THRESHOLD")
+    # HTTP server performance and hybrid system settings removed for pure MCP server
     
     # Note: FastAPI-related settings have been removed as FastAPI server functionality 
     # has been eliminated from the MCP server implementation
     
-    @validator("allowed_origins", pre=True)
-    def parse_allowed_origins(cls, v):
-        """Parse allowed origins from environment variable"""
-        if isinstance(v, str):
-            return [origin.strip() for origin in v.split(",") if origin.strip()]
-        return v
+    # HTTP server related validators removed
     
     @validator("allowed_ips", pre=True)
     def parse_allowed_ips(cls, v):
@@ -137,12 +79,7 @@ class Settings(BaseSettings):
             return [ip.strip() for ip in v.split(",") if ip.strip()]
         return v
     
-    @validator("trusted_hosts", pre=True)
-    def parse_trusted_hosts(cls, v):
-        """Parse trusted hosts from environment variable"""
-        if isinstance(v, str):
-            return [host.strip() for host in v.split(",") if host.strip()]
-        return v
+    # trusted_hosts validator removed
     
     @validator("environment")
     def validate_environment(cls, v):
@@ -157,14 +94,6 @@ class Settings(BaseSettings):
         errors = []
         
         if self.environment == "production":
-            # Check for wildcard CORS origins
-            if "*" in self.allowed_origins:
-                errors.append("CORS wildcard (*) is not allowed in production environment")
-            
-            # Check for SSL/TLS configuration
-            if not self.ssl_enabled:
-                errors.append("SSL/TLS must be enabled in production environment")
-            
             # Check for strong JWT secret
             if not self.jwt_secret or len(self.jwt_secret) < 32:
                 errors.append("JWT secret must be at least 32 characters long in production")
@@ -172,10 +101,6 @@ class Settings(BaseSettings):
             # Check for authentication passwords
             if not self.admin_password:
                 errors.append("Admin password must be set in production")
-            
-            # Check for trusted hosts
-            if not self.trusted_hosts_enabled or "*" in self.trusted_hosts:
-                errors.append("Trusted hosts must be configured and not use wildcard in production")
         
         if errors:
             raise ValueError(f"Production configuration errors: {'; '.join(errors)}")

--- a/mcp-server/docs/plan/PHASE2_README.md
+++ b/mcp-server/docs/plan/PHASE2_README.md
@@ -38,8 +38,7 @@ mcp-server/
 │   │   ├── backend_client.py           # Backend API communication
 │   │   └── nlp_engine.py              # Original NLP (backward compatibility)
 │   ├── models/                         # Data models (unchanged)
-│   ├── enhanced_main.py               # Enhanced FastAPI application
-│   └── main.py                        # Original main (backward compatibility)
+│   └── mcp_main.py                     # MCP Server main application
 ├── tests/
 │   ├── test_enhanced_nlp_engine.py    # Enhanced NLP tests
 │   ├── test_enhanced_command_router.py # Enhanced router tests
@@ -62,13 +61,13 @@ cd mcp-server
 pip install -r requirements.txt
 ```
 
-### Start Enhanced Server
+### Start MCP Server
 ```bash
-# Enhanced server with Phase 2 features
-python src/enhanced_main.py
+# MCP Server with Phase 2 enhanced features
+python start_mcp_server_unified.py
 
-# Or using the startup script
-python start_mcp_server.py --enhanced
+# Or direct MCP server startup
+python src/mcp_main.py
 ```
 
 ## 🧠 Enhanced Natural Language Processing

--- a/mcp-server/docs/plan/PHASE6_DOCUMENTATION.md
+++ b/mcp-server/docs/plan/PHASE6_DOCUMENTATION.md
@@ -42,36 +42,34 @@ MFG Drone システム全体アーキテクチャ:
                        └─────────────────┘    └─────────────────┘
 ```
 
-#### 1.2 API仕様書
+#### 1.2 MCP Tools仕様書
 ```yaml
-# MCP API エンドポイント (25個のAPI)
+# MCP Tools (Model Context Protocol準拠)
 # 基本指令系統
-POST /mcp/command                    # 自然言語コマンド実行
-POST /mcp/command/batch              # バッチ処理
-POST /mcp/command/enhanced           # 強化版処理 (Phase 2+)
+execute_natural_language_command     # 自然言語コマンド実行
+execute_batch_commands               # バッチ処理
 
 # ドローン制御系統
-GET  /mcp/drones                     # ドローン一覧
-POST /mcp/drones/{id}/connect        # 接続
-POST /mcp/drones/{id}/takeoff        # 離陸
-POST /mcp/drones/{id}/land           # 着陸
-POST /mcp/drones/{id}/move           # 移動
-POST /mcp/drones/{id}/rotate         # 回転
-POST /mcp/drones/{id}/altitude       # 高度調整
-POST /mcp/drones/{id}/emergency      # 緊急停止
+connect_drone                        # ドローン接続
+takeoff_drone                        # 離陸
+land_drone                           # 着陸
+move_drone                           # 移動
+rotate_drone                         # 回転
+emergency_stop                       # 緊急停止
 
 # カメラ・ビジョン系統
-POST /mcp/drones/{id}/camera/photo   # 写真撮影
-POST /mcp/drones/{id}/camera/streaming # ストリーミング
-POST /mcp/drones/{id}/learning/collect # 学習データ収集
-POST /mcp/vision/detection           # 物体検出
-POST /mcp/vision/tracking            # 物体追跡
+take_photo                           # 写真撮影
+start_streaming                      # ストリーミング開始
+stop_streaming                       # ストリーミング停止
 
 # システム管理系統
-GET  /mcp/system/status              # システム状態
-GET  /mcp/system/health              # ヘルスチェック
-GET  /mcp/system/performance         # パフォーマンス監視 (Phase 5)
-GET  /mcp/security/summary           # セキュリティ状況 (Phase 5)
+get_system_status                    # システム状態
+get_drone_status                     # ドローン状態
+
+# Resources (リソース)
+drone://available                    # 利用可能なドローン一覧
+drone://status/{drone_id}            # ドローン状態
+system://status                      # システム状態
 ```
 
 #### 1.3 自然言語コマンド辞書
@@ -132,54 +130,51 @@ emergency_patterns:
   - "emergency stop"
 ```
 
-#### 1.4 コードサンプル集
+#### 1.4 MCP Client使用例
 ```python
-# 基本的なMCPクライアント使用例
-import requests
-import json
+# MCP (Model Context Protocol) クライアント使用例
+# 注意: 実際のMCPクライアントはstdio経由で通信します
 
-class MCPClient:
-    def __init__(self, base_url="http://localhost:8001"):
-        self.base_url = base_url
-        self.session = requests.Session()
+from mcp import ClientSession
+import asyncio
+
+class MCPDroneClient:
+    def __init__(self, server_path="src/mcp_main.py"):
+        self.server_path = server_path
     
-    def execute_command(self, command: str) -> dict:
+    async def execute_command(self, command: str) -> dict:
         """自然言語コマンドを実行"""
-        response = self.session.post(
-            f"{self.base_url}/mcp/command",
-            json={"command": command}
-        )
-        return response.json()
+        # MCPクライアントを通じてツールを呼び出し
+        async with ClientSession() as session:
+            result = await session.call_tool(
+                "execute_natural_language_command",
+                {"command": command}
+            )
+            return result
     
-    def batch_execute(self, commands: list) -> dict:
-        """複数コマンドを一括実行"""
-        payload = {
-            "commands": [{"command": cmd} for cmd in commands],
-            "execution_mode": "sequential"
-        }
-        response = self.session.post(
-            f"{self.base_url}/mcp/command/batch",
-            json=payload
-        )
-        return response.json()
+    async def connect_drone(self, drone_type: str = "tello") -> dict:
+        """ドローンに接続"""
+        async with ClientSession() as session:
+            result = await session.call_tool(
+                "connect_drone",
+                {"drone_type": drone_type}
+            )
+            return result
 
 # 使用例
-client = MCPClient()
+async def main():
+    client = MCPDroneClient()
+    
+    # ドローンに接続
+    result = await client.connect_drone("tello")
+    print(f"接続結果: {result}")
+    
+    # 自然言語コマンド実行
+    result = await client.execute_command("ドローンを離陸させて")
+    print(f"実行結果: {result}")
 
-# 単一コマンド実行
-result = client.execute_command("ドローンAAに接続して")
-print(f"結果: {result['success']}")
-
-# バッチ実行
-commands = [
-    "ドローンAAに接続して",
-    "離陸して",
-    "右に50センチ移動して",
-    "写真を撮って",
-    "着陸して"
-]
-result = client.batch_execute(commands)
-print(f"成功: {result['summary']['successful_commands']}/5")
+# 実行
+asyncio.run(main())
 ```
 
 ### 2. 運用者向けドキュメント
@@ -193,7 +188,7 @@ python start_api_server.py
 
 # 2. MCP Server (Windows PC)
 cd mcp-server
-python start_mcp_server.py
+python start_mcp_server_unified.py
 
 # 3. Frontend (Windows PC)
 cd frontend
@@ -208,7 +203,7 @@ kubectl apply -f k8s/
 
 # 3. システムヘルスチェック
 curl http://localhost:8000/health        # Backend
-curl http://localhost:8001/mcp/system/health # MCP Server
+# MCP Server: MCP Protocolで動作（HTTPアクセス不可）
 curl http://localhost:3000               # Frontend
 ```
 
@@ -222,7 +217,7 @@ curl http://localhost:9090/targets
 open http://localhost:3001
 
 # 3. リアルタイム監視
-curl http://localhost:8001/mcp/system/performance
+# MCP Serverはstdio経由でのみ通信（HTTPアクセス不可）
 
 # === ログ管理 ===
 # 1. システムログ確認
@@ -246,24 +241,19 @@ tar -czf config_backup_$(date +%Y%m%d).tar.gz config/
 
 #### 2.3 セキュリティ管理
 ```bash
-# === API Key管理 ===
-# 1. 新しいAPI Key生成
-curl -X POST http://localhost:8001/mcp/auth/api-key \
-  -H "Authorization: Bearer admin-token" \
-  -d '{"user_id": "new_user", "permissions": ["read", "write"]}'
-
-# 2. API Key無効化
-curl -X DELETE http://localhost:8001/mcp/auth/api-key/{key_id} \
-  -H "Authorization: Bearer admin-token"
+# === MCP Server セキュリティ管理 ===
+# MCP Serverはstdio経由でのみ通信するため、
+# HTTPベースのAPIは提供されません
 
 # === セキュリティ監査 ===
-# 1. セキュリティイベント確認
-curl -H "Authorization: Bearer admin-token" \
-  http://localhost:8001/mcp/security/events
+# 1. セキュリティログ確認
+tail -f logs/mcp-security.log
 
-# 2. 脅威分析レポート
-curl -H "Authorization: Bearer admin-token" \
-  http://localhost:8001/mcp/security/threats
+# 2. 監査ログ確認
+grep SECURITY logs/mcp-server.log
+
+# 3. 設定ファイルの確認
+cat config/settings.py | grep -i security
 ```
 
 ### 3. 利用者向けドキュメント
@@ -566,13 +556,13 @@ pytest --cov=src tests/
 ### デバッグ
 ```bash
 # デバッグモード起動
-DEBUG=true python start_mcp_server.py
+DEBUG=true python start_mcp_server_unified.py
 
 # ログレベル調整
-LOG_LEVEL=DEBUG python start_mcp_server.py
+LOG_LEVEL=DEBUG python start_mcp_server_unified.py
 
 # パフォーマンス分析
-python -m cProfile start_mcp_server.py
+python -m cProfile start_mcp_server_unified.py
 ```
 
 ## 📊 システム仕様

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -35,7 +35,4 @@ Pillow==10.1.0  # For image processing
 # MCP (Model Context Protocol) SDK
 mcp==1.0.0
 
-# Hybrid system dependencies (Phase 3)
-psutil==5.9.6  # System monitoring
-aiohttp==3.9.1  # Async HTTP client for health checks
-multiprocessing-logging==0.3.4  # Logging for multiprocessing
+# Hybrid system dependencies removed - pure MCP server only


### PR DESCRIPTION
Phase 4の実行により、MCPサーバからAPIサーバ機能を完全に除去しました。

## 変更内容

### 1. 依存関係の整理
- `requirements.txt`：ハイブリッドシステム依存関係を3つ削除

### 2. 設定ファイルの整理
- `config/settings.py`：HTTPサーバ、CORS、セキュリティヘッダー、レート制限、SSL/TLS、ハイブリッドシステム設定を除去

### 3. ドキュメントの更新
- `docs/plan/PHASE6_DOCUMENTATION.md`：HTTP API仕様をMCP Tools仕様に更新
- `docs/plan/PHASE2_README.md`：FastAPIアプリケーション参照を削除

## 効果

この変更により、MCPサーバは純粋なModel Context Protocol機能のみを提供し、APIサーバ機能はbackendプロジェクトで管理されます。

関連イシュー: #90 残フェーズあり

🤖 Generated with [Claude Code](https://claude.ai/code)