### PR TITLE
feat: Phase 3 - バックエンド連携・HTTP Client実装完了

### DIFF
--- a/mcp-server-nodejs/README.md
+++ b/mcp-server-nodejs/README.md
@@ -9,11 +9,16 @@ Tello EDU ドローン制御システム用のMCP (Model Context Protocol) サ�
 ## 主な機能
 
 - **MCP Protocol対応**: Model Context Protocolを使用したClaude統合
-- **ドローン状態管理**: Tello EDUドローンの状態監視・制御
+- **包括的ドローン制御**: 離陸・着陸・移動・回転・緊急停止
+- **カメラ操作**: 写真撮影・ストリーミング制御
+- **ビジョンAPI**: 物体検出・追跡・データセット管理
+- **モデル管理**: AI学習モデルの作成・管理・学習ジョブ監視
+- **ダッシュボード機能**: システム状態・ドローン群監視
 - **自動スキャン**: ネットワーク上のドローン自動検出
 - **ヘルスチェック**: システム健全性監視
+- **接続テスト**: バックエンドAPI連携の自動検証
 - **TypeScript厳密設定**: 型安全性を重視した実装
-- **包括的テスト**: 単体テスト・統合テストによる品質保証
+- **包括的テスト**: 単体テスト・統合テスト・接続テストによる品質保証
 
 ## 技術スタック
 
@@ -88,6 +93,9 @@ npm run test:watch
 
 # カバレッジレポート
 npm run test:coverage
+
+# バックエンドAPI接続テスト
+npm run test:connection
 ```
 
 ### コード品質チェック
@@ -166,14 +174,16 @@ src/
 ├── clients/                 # 外部API通信
 │   └── BackendClient.ts
 ├── types/                   # 型定義
-│   └── index.ts
+│   ├── index.ts             # 基本型定義
+│   └── api_types.ts         # バックエンドAPI型定義
 ├── utils/                   # ユーティリティ
 │   ├── logger.ts
 │   └── errors.ts
 ├── config/                  # 設定管理
 │   └── index.ts
-└── test/                    # テスト共通設定
-    └── setup.ts
+└── test/                    # テスト関連
+    ├── setup.ts             # テスト共通設定
+    └── connection-test.ts   # バックエンド接続テスト
 ```
 
 ### 主要コンポーネント
@@ -221,6 +231,15 @@ Error: Backend connection failed: http://localhost:8000
 - FastAPIサーバーが起動していることを確認
 - `BACKEND_URL`環境変数が正しく設定されていることを確認
 - ファイアウォールの設定を確認
+
+**接続テストの実行**:
+```bash
+# バックエンドとの接続を包括的にテスト
+npm run test:connection
+
+# 特定のバックエンドURLでテスト
+BACKEND_URL=http://localhost:8001 npm run test:connection
+```
 
 #### 2. MCP SDK エラー
 

--- a/mcp-server-nodejs/package.json
+++ b/mcp-server-nodejs/package.json
@@ -11,6 +11,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:connection": "tsx src/test/connection-test.ts",
     "lint": "eslint 'src/**/*.{ts,js}'",
     "lint:fix": "eslint 'src/**/*.{ts,js}' --fix",
     "format": "prettier --write 'src/**/*.{ts,js}'",

--- a/mcp-server-nodejs/src/clients/BackendClient.ts
+++ b/mcp-server-nodejs/src/clients/BackendClient.ts
@@ -3,6 +3,28 @@ import { logger } from '@/utils/logger.js';
 import { ErrorHandler } from '@/utils/errors.js';
 import { NetworkError, type DroneStatus, type SystemStatus } from '@/types/index.js';
 import type { Config } from '@/types/index.js';
+import type {
+  Drone,
+  MoveCommand,
+  RotateCommand,
+  Photo,
+  Dataset,
+  CreateDatasetRequest,
+  DatasetImage,
+  DetectionRequest,
+  DetectionResult,
+  StartTrackingRequest,
+  TrackingStatus,
+  Model,
+  TrainModelRequest,
+  TrainingJob,
+  ScanDronesResponse,
+  HealthCheckResponse,
+  CommandResponse,
+  SuccessResponse,
+  ErrorResponse,
+  FileUploadFormData,
+} from '@/types/api_types.js';
 
 /**
  * バックエンドAPIクライアント
@@ -67,6 +89,23 @@ export class BackendClient {
     );
   }
 
+  // ========================================
+  // Drone Management APIs
+  // ========================================
+
+  /**
+   * ドローン一覧を取得
+   */
+  async getDrones(): Promise<Drone[]> {
+    try {
+      const response: AxiosResponse<Drone[]> = await this.client.get('/api/drones');
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getDrones');
+      throw handledError;
+    }
+  }
+
   /**
    * ドローンの状態を取得
    */
@@ -84,11 +123,109 @@ export class BackendClient {
   }
 
   /**
+   * ドローンに接続
+   */
+  async connectDrone(droneId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/connect`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.connectDrone');
+      throw handledError;
+    }
+  }
+
+  /**
+   * ドローンから切断
+   */
+  async disconnectDrone(droneId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/disconnect`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.disconnectDrone');
+      throw handledError;
+    }
+  }
+
+  /**
+   * ドローンを離陸
+   */
+  async takeoffDrone(droneId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/takeoff`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.takeoffDrone');
+      throw handledError;
+    }
+  }
+
+  /**
+   * ドローンを着陸
+   */
+  async landDrone(droneId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/land`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.landDrone');
+      throw handledError;
+    }
+  }
+
+  /**
+   * ドローンを移動
+   */
+  async moveDrone(droneId: string, command: MoveCommand): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/move`, command);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.moveDrone');
+      throw handledError;
+    }
+  }
+
+  /**
+   * ドローンを回転
+   */
+  async rotateDrone(droneId: string, command: RotateCommand): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/rotate`, command);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.rotateDrone');
+      throw handledError;
+    }
+  }
+
+  /**
+   * ドローンを緊急停止
+   */
+  async emergencyStopDrone(droneId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/emergency`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.emergencyStopDrone');
+      throw handledError;
+    }
+  }
+
+  /**
    * ドローンをスキャン
    */
-  async scanDrones(): Promise<{ message: string; found: number }> {
+  async scanDrones(): Promise<ScanDronesResponse> {
     try {
-      const response: AxiosResponse<{ message: string; found: number }> = 
+      const response: AxiosResponse<ScanDronesResponse> = 
         await this.client.post('/api/drones/scan');
       return response.data;
     } catch (error) {
@@ -97,12 +234,62 @@ export class BackendClient {
     }
   }
 
+  // ========================================
+  // Camera APIs
+  // ========================================
+
+  /**
+   * カメラストリーミング開始
+   */
+  async startCameraStream(droneId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/camera/stream/start`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.startCameraStream');
+      throw handledError;
+    }
+  }
+
+  /**
+   * カメラストリーミング停止
+   */
+  async stopCameraStream(droneId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post(`/api/drones/${droneId}/camera/stream/stop`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.stopCameraStream');
+      throw handledError;
+    }
+  }
+
+  /**
+   * 写真撮影
+   */
+  async takePhoto(droneId: string): Promise<Photo> {
+    try {
+      const response: AxiosResponse<Photo> = 
+        await this.client.post(`/api/drones/${droneId}/camera/photo`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.takePhoto');
+      throw handledError;
+    }
+  }
+
+  // ========================================
+  // System APIs
+  // ========================================
+
   /**
    * システムの健全性をチェック
    */
-  async healthCheck(): Promise<{ status: string; timestamp: string }> {
+  async healthCheck(): Promise<HealthCheckResponse> {
     try {
-      const response: AxiosResponse<{ status: string; timestamp: string }> = 
+      const response: AxiosResponse<HealthCheckResponse> = 
         await this.client.get('/api/system/health');
       return response.data;
     } catch (error) {
@@ -127,9 +314,9 @@ export class BackendClient {
   /**
    * ドローンコマンドを実行
    */
-  async executeCommand(droneId: string, command: string, params?: Record<string, unknown>): Promise<{ success: boolean; message: string }> {
+  async executeCommand(droneId: string, command: string, params?: Record<string, unknown>): Promise<CommandResponse> {
     try {
-      const response: AxiosResponse<{ success: boolean; message: string }> = 
+      const response: AxiosResponse<CommandResponse> = 
         await this.client.post(`/api/drones/${droneId}/command`, {
           command,
           params: params || {},
@@ -137,6 +324,244 @@ export class BackendClient {
       return response.data;
     } catch (error) {
       const handledError = ErrorHandler.handleError(error, 'BackendClient.executeCommand');
+      throw handledError;
+    }
+  }
+
+  // ========================================
+  // Vision APIs
+  // ========================================
+
+  /**
+   * データセット一覧を取得
+   */
+  async getDatasets(): Promise<Dataset[]> {
+    try {
+      const response: AxiosResponse<Dataset[]> = await this.client.get('/api/vision/datasets');
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getDatasets');
+      throw handledError;
+    }
+  }
+
+  /**
+   * データセットを作成
+   */
+  async createDataset(request: CreateDatasetRequest): Promise<Dataset> {
+    try {
+      const response: AxiosResponse<Dataset> = 
+        await this.client.post('/api/vision/datasets', request);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.createDataset');
+      throw handledError;
+    }
+  }
+
+  /**
+   * データセット詳細を取得
+   */
+  async getDataset(datasetId: string): Promise<Dataset> {
+    try {
+      const response: AxiosResponse<Dataset> = 
+        await this.client.get(`/api/vision/datasets/${datasetId}`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getDataset');
+      throw handledError;
+    }
+  }
+
+  /**
+   * データセットを削除
+   */
+  async deleteDataset(datasetId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.delete(`/api/vision/datasets/${datasetId}`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.deleteDataset');
+      throw handledError;
+    }
+  }
+
+  /**
+   * データセットに画像を追加
+   */
+  async addImageToDataset(datasetId: string, formData: FormData): Promise<DatasetImage> {
+    try {
+      const response: AxiosResponse<DatasetImage> = 
+        await this.client.post(`/api/vision/datasets/${datasetId}/images`, formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        });
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.addImageToDataset');
+      throw handledError;
+    }
+  }
+
+  /**
+   * 物体検出を実行
+   */
+  async detectObjects(request: DetectionRequest): Promise<DetectionResult> {
+    try {
+      const response: AxiosResponse<DetectionResult> = 
+        await this.client.post('/api/vision/detection', request);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.detectObjects');
+      throw handledError;
+    }
+  }
+
+  /**
+   * 物体追跡を開始
+   */
+  async startTracking(request: StartTrackingRequest): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post('/api/vision/tracking/start', request);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.startTracking');
+      throw handledError;
+    }
+  }
+
+  /**
+   * 物体追跡を停止
+   */
+  async stopTracking(): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.post('/api/vision/tracking/stop');
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.stopTracking');
+      throw handledError;
+    }
+  }
+
+  /**
+   * 物体追跡の状態を取得
+   */
+  async getTrackingStatus(): Promise<TrackingStatus> {
+    try {
+      const response: AxiosResponse<TrackingStatus> = 
+        await this.client.get('/api/vision/tracking/status');
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getTrackingStatus');
+      throw handledError;
+    }
+  }
+
+  // ========================================
+  // Model Management APIs
+  // ========================================
+
+  /**
+   * モデル一覧を取得
+   */
+  async getModels(): Promise<Model[]> {
+    try {
+      const response: AxiosResponse<Model[]> = await this.client.get('/api/models');
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getModels');
+      throw handledError;
+    }
+  }
+
+  /**
+   * モデル学習を開始
+   */
+  async trainModel(request: TrainModelRequest): Promise<TrainingJob> {
+    try {
+      const response: AxiosResponse<TrainingJob> = 
+        await this.client.post('/api/models', request);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.trainModel');
+      throw handledError;
+    }
+  }
+
+  /**
+   * モデル詳細を取得
+   */
+  async getModel(modelId: string): Promise<Model> {
+    try {
+      const response: AxiosResponse<Model> = 
+        await this.client.get(`/api/models/${modelId}`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getModel');
+      throw handledError;
+    }
+  }
+
+  /**
+   * モデルを削除
+   */
+  async deleteModel(modelId: string): Promise<SuccessResponse> {
+    try {
+      const response: AxiosResponse<SuccessResponse> = 
+        await this.client.delete(`/api/models/${modelId}`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.deleteModel');
+      throw handledError;
+    }
+  }
+
+  /**
+   * 学習ジョブの状況を取得
+   */
+  async getTrainingJob(jobId: string): Promise<TrainingJob> {
+    try {
+      const response: AxiosResponse<TrainingJob> = 
+        await this.client.get(`/api/models/training/${jobId}`);
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getTrainingJob');
+      throw handledError;
+    }
+  }
+
+  // ========================================
+  // Dashboard APIs
+  // ========================================
+
+  /**
+   * ダッシュボード用ドローン群状態を取得
+   */
+  async getDashboardDrones(): Promise<DroneStatus[]> {
+    try {
+      const response: AxiosResponse<DroneStatus[]> = 
+        await this.client.get('/api/dashboard/drones');
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getDashboardDrones');
+      throw handledError;
+    }
+  }
+
+  /**
+   * ダッシュボード用システム状態を取得
+   */
+  async getDashboardSystemStatus(): Promise<SystemStatus> {
+    try {
+      const response: AxiosResponse<SystemStatus> = 
+        await this.client.get('/api/dashboard/system');
+      return response.data;
+    } catch (error) {
+      const handledError = ErrorHandler.handleError(error, 'BackendClient.getDashboardSystemStatus');
       throw handledError;
     }
   }

--- a/mcp-server-nodejs/src/test/connection-test.ts
+++ b/mcp-server-nodejs/src/test/connection-test.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env tsx
+
+/**
+ * バックエンドAPI接続テストスクリプト
+ * 
+ * このスクリプトは、MCPサーバーのBackendClientが
+ * Pythonバックエンドと正しく連携できるかをテストします。
+ */
+
+import { BackendClient } from '@/clients/BackendClient.js';
+import { logger } from '@/utils/logger.js';
+import { Config } from '@/types/index.js';
+
+// テスト設定
+const testConfig: Config = {
+  port: 3001,
+  backendUrl: process.env.BACKEND_URL || 'http://localhost:8000',
+  logLevel: process.env.LOG_LEVEL as any || 'info',
+  timeout: parseInt(process.env.TIMEOUT || '10000', 10),
+};
+
+// テスト結果集計
+interface TestResult {
+  name: string;
+  passed: boolean;
+  error?: string;
+  duration: number;
+}
+
+class ConnectionTester {
+  private client: BackendClient;
+  private results: TestResult[] = [];
+
+  constructor() {
+    this.client = new BackendClient(testConfig);
+  }
+
+  /**
+   * 個別テストを実行
+   */
+  private async runTest(name: string, testFn: () => Promise<void>): Promise<void> {
+    const startTime = Date.now();
+    try {
+      await testFn();
+      const duration = Date.now() - startTime;
+      this.results.push({ name, passed: true, duration });
+      logger.info(`✅ ${name} - ${duration}ms`);
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.results.push({ name, passed: false, error: errorMessage, duration });
+      logger.error(`❌ ${name} - ${duration}ms: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * 基本接続テスト
+   */
+  async testBasicConnection(): Promise<void> {
+    await this.runTest('Basic Connection Test', async () => {
+      const isConnected = await this.client.testConnection();
+      if (!isConnected) {\n        throw new Error('Backend connection failed');\n      }\n    });\n  }\n\n  /**\n   * ヘルスチェックテスト\n   */\n  async testHealthCheck(): Promise<void> {\n    await this.runTest('Health Check Test', async () => {\n      const health = await this.client.healthCheck();\n      if (!health.status) {\n        throw new Error('Health check returned no status');\n      }\n      if (!health.timestamp) {\n        throw new Error('Health check returned no timestamp');\n      }\n    });\n  }\n\n  /**\n   * システム状態テスト\n   */\n  async testSystemStatus(): Promise<void> {\n    await this.runTest('System Status Test', async () => {\n      const status = await this.client.getSystemStatus();\n      if (typeof status.cpu_usage !== 'number') {\n        throw new Error('Invalid system status format');\n      }\n    });\n  }\n\n  /**\n   * ドローン一覧取得テスト\n   */\n  async testGetDrones(): Promise<void> {\n    await this.runTest('Get Drones Test', async () => {\n      const drones = await this.client.getDrones();\n      if (!Array.isArray(drones)) {\n        throw new Error('Drones response is not an array');\n      }\n      logger.info(`Found ${drones.length} drone(s)`);\n    });\n  }\n\n  /**\n   * ドローンスキャンテスト\n   */\n  async testScanDrones(): Promise<void> {\n    await this.runTest('Scan Drones Test', async () => {\n      const result = await this.client.scanDrones();\n      if (typeof result.found !== 'number') {\n        throw new Error('Invalid scan result format');\n      }\n      logger.info(`Scan found ${result.found} drone(s): ${result.message}`);\n    });\n  }\n\n  /**\n   * データセット一覧取得テスト\n   */\n  async testGetDatasets(): Promise<void> {\n    await this.runTest('Get Datasets Test', async () => {\n      const datasets = await this.client.getDatasets();\n      if (!Array.isArray(datasets)) {\n        throw new Error('Datasets response is not an array');\n      }\n      logger.info(`Found ${datasets.length} dataset(s)`);\n    });\n  }\n\n  /**\n   * モデル一覧取得テスト\n   */\n  async testGetModels(): Promise<void> {\n    await this.runTest('Get Models Test', async () => {\n      const models = await this.client.getModels();\n      if (!Array.isArray(models)) {\n        throw new Error('Models response is not an array');\n      }\n      logger.info(`Found ${models.length} model(s)`);\n    });\n  }\n\n  /**\n   * 物体追跡状態取得テスト\n   */\n  async testGetTrackingStatus(): Promise<void> {\n    await this.runTest('Get Tracking Status Test', async () => {\n      const status = await this.client.getTrackingStatus();\n      if (typeof status.is_active !== 'boolean') {\n        throw new Error('Invalid tracking status format');\n      }\n      logger.info(`Tracking active: ${status.is_active}`);\n    });\n  }\n\n  /**\n   * ダッシュボード機能テスト\n   */\n  async testDashboardAPIs(): Promise<void> {\n    await this.runTest('Dashboard System Status Test', async () => {\n      const systemStatus = await this.client.getDashboardSystemStatus();\n      if (typeof systemStatus.cpu_usage !== 'number') {\n        throw new Error('Invalid dashboard system status format');\n      }\n    });\n\n    await this.runTest('Dashboard Drones Test', async () => {\n      const drones = await this.client.getDashboardDrones();\n      if (!Array.isArray(drones)) {\n        throw new Error('Dashboard drones response is not an array');\n      }\n      logger.info(`Dashboard shows ${drones.length} drone(s)`);\n    });\n  }\n\n  /**\n   * レスポンスタイム計測テスト\n   */\n  async testResponseTimes(): Promise<void> {\n    await this.runTest('Response Time Test', async () => {\n      const iterations = 5;\n      const times: number[] = [];\n\n      for (let i = 0; i < iterations; i++) {\n        const start = Date.now();\n        await this.client.healthCheck();\n        times.push(Date.now() - start);\n      }\n\n      const average = times.reduce((a, b) => a + b, 0) / times.length;\n      const max = Math.max(...times);\n      const min = Math.min(...times);\n\n      logger.info(`Response times - Avg: ${average.toFixed(1)}ms, Min: ${min}ms, Max: ${max}ms`);\n\n      if (average > 5000) {\n        throw new Error(`Average response time too slow: ${average.toFixed(1)}ms`);\n      }\n    });\n  }\n\n  /**\n   * エラーハンドリングテスト\n   */\n  async testErrorHandling(): Promise<void> {\n    await this.runTest('Error Handling Test', async () => {\n      try {\n        // 存在しないドローンIDでテスト\n        await this.client.getDroneStatus('non-existent-drone-id');\n        throw new Error('Expected error was not thrown');\n      } catch (error) {\n        if (error instanceof Error && error.message === 'Expected error was not thrown') {\n          throw error;\n        }\n        // エラーが正しく処理されることを確認\n        logger.info('Error handling working correctly');\n      }\n    });\n  }\n\n  /**\n   * 全テストを実行\n   */\n  async runAllTests(): Promise<void> {\n    logger.info(`🚀 Starting connection tests for backend: ${testConfig.backendUrl}`);\n    logger.info('='repeat(50));\n\n    // 基本接続テスト\n    await this.testBasicConnection();\n    await this.testHealthCheck();\n    await this.testSystemStatus();\n\n    // ドローン関連テスト\n    await this.testGetDrones();\n    await this.testScanDrones();\n\n    // ビジョン関連テスト\n    await this.testGetDatasets();\n    await this.testGetModels();\n    await this.testGetTrackingStatus();\n\n    // ダッシュボードテスト\n    await this.testDashboardAPIs();\n\n    // パフォーマンステスト\n    await this.testResponseTimes();\n\n    // エラーハンドリングテスト\n    await this.testErrorHandling();\n\n    // 結果表示\n    this.displayResults();\n  }\n\n  /**\n   * テスト結果を表示\n   */\n  private displayResults(): void {\n    logger.info('='repeat(50));\n    logger.info('📊 Test Results Summary');\n    logger.info('='repeat(50));\n\n    const passed = this.results.filter(r => r.passed).length;\n    const total = this.results.length;\n    const successRate = ((passed / total) * 100).toFixed(1);\n\n    logger.info(`✅ Passed: ${passed}/${total} (${successRate}%)`);\n    logger.info(`❌ Failed: ${total - passed}/${total}`);\n\n    if (passed < total) {\n      logger.info('\\n🔍 Failed Tests:');\n      this.results\n        .filter(r => !r.passed)\n        .forEach(r => {\n          logger.error(`  - ${r.name}: ${r.error}`);\n        });\n    }\n\n    const avgDuration = this.results.reduce((sum, r) => sum + r.duration, 0) / this.results.length;\n    logger.info(`\\n⏱️  Average test duration: ${avgDuration.toFixed(1)}ms`);\n\n    if (passed === total) {\n      logger.info('\\n🎉 All tests passed! Backend connection is healthy.');\n    } else {\n      logger.error('\\n⚠️  Some tests failed. Please check the backend configuration.');\n      process.exit(1);\n    }\n  }\n}\n\n// メイン実行関数\nasync function main(): Promise<void> {\n  const tester = new ConnectionTester();\n  \n  try {\n    await tester.runAllTests();\n  } catch (error) {\n    logger.error('Test execution failed:', error);\n    process.exit(1);\n  }\n}\n\n// コマンドライン実行時\nif (import.meta.url === `file://${process.argv[1]}`) {\n  main().catch(error => {\n    logger.error('Unhandled error:', error);\n    process.exit(1);\n  });\n}\n\nexport { ConnectionTester };

--- a/mcp-server-nodejs/src/types/api_types.ts
+++ b/mcp-server-nodejs/src/types/api_types.ts
@@ -1,0 +1,332 @@
+import { z } from 'zod';
+
+// ========================================
+// Common API Types
+// ========================================
+
+export const SuccessResponseSchema = z.object({
+  success: z.boolean().default(true),
+  message: z.string(),
+  timestamp: z.string().datetime(),
+});
+
+export type SuccessResponse = z.infer<typeof SuccessResponseSchema>;
+
+export const ErrorResponseSchema = z.object({
+  error: z.boolean().default(true),
+  error_code: z.string(),
+  message: z.string(),
+  details: z.string().optional(),
+  timestamp: z.string().datetime(),
+});
+
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+
+// ========================================
+// Drone API Types
+// ========================================
+
+export const AttitudeSchema = z.object({
+  pitch: z.number().min(-180).max(180),
+  roll: z.number().min(-180).max(180),
+  yaw: z.number().min(-180).max(180),
+});
+
+export type Attitude = z.infer<typeof AttitudeSchema>;
+
+export const DroneSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(['real', 'dummy']),
+  ip_address: z.string().ip().optional(),
+  status: z.enum(['disconnected', 'connected', 'flying', 'landed', 'error']),
+  last_seen: z.string().datetime(),
+});
+
+export type Drone = z.infer<typeof DroneSchema>;
+
+export const DroneStatusSchema = z.object({
+  drone_id: z.string(),
+  connection_status: z.enum(['disconnected', 'connected', 'error']),
+  flight_status: z.enum(['landed', 'flying', 'hovering', 'landing', 'taking_off']),
+  battery_level: z.number().min(0).max(100),
+  flight_time: z.number().min(0),
+  height: z.number().min(0),
+  temperature: z.number(),
+  speed: z.number().min(0),
+  wifi_signal: z.number().min(0).max(100),
+  attitude: AttitudeSchema.optional(),
+  last_updated: z.string().datetime(),
+});
+
+export type DroneStatus = z.infer<typeof DroneStatusSchema>;
+
+export const MoveCommandSchema = z.object({
+  direction: z.enum(['up', 'down', 'left', 'right', 'forward', 'back']),
+  distance: z.number().min(20).max(500),
+});
+
+export type MoveCommand = z.infer<typeof MoveCommandSchema>;
+
+export const RotateCommandSchema = z.object({
+  direction: z.enum(['clockwise', 'counter_clockwise']),
+  angle: z.number().min(1).max(360),
+});
+
+export type RotateCommand = z.infer<typeof RotateCommandSchema>;
+
+export const PhotoSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+  path: z.string(),
+  timestamp: z.string().datetime(),
+  drone_id: z.string(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type Photo = z.infer<typeof PhotoSchema>;
+
+// ========================================
+// Vision API Types
+// ========================================
+
+export const DatasetSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  image_count: z.number().min(0),
+  labels: z.array(z.string()),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+export type Dataset = z.infer<typeof DatasetSchema>;
+
+export const CreateDatasetRequestSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional(),
+});
+
+export type CreateDatasetRequest = z.infer<typeof CreateDatasetRequestSchema>;
+
+export const DatasetImageSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+  path: z.string(),
+  label: z.string(),
+  dataset_id: z.string(),
+  uploaded_at: z.string().datetime(),
+});
+
+export type DatasetImage = z.infer<typeof DatasetImageSchema>;
+
+export const BoundingBoxSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+});
+
+export type BoundingBox = z.infer<typeof BoundingBoxSchema>;
+
+export const DetectionSchema = z.object({
+  label: z.string(),
+  confidence: z.number().min(0).max(1),
+  bbox: BoundingBoxSchema,
+});
+
+export type Detection = z.infer<typeof DetectionSchema>;
+
+export const DetectionRequestSchema = z.object({
+  image: z.string(), // Base64 encoded
+  model_id: z.string(),
+  confidence_threshold: z.number().min(0).max(1).default(0.5),
+});
+
+export type DetectionRequest = z.infer<typeof DetectionRequestSchema>;
+
+export const DetectionResultSchema = z.object({
+  detections: z.array(DetectionSchema),
+  processing_time: z.number(),
+  model_id: z.string(),
+});
+
+export type DetectionResult = z.infer<typeof DetectionResultSchema>;
+
+export const StartTrackingRequestSchema = z.object({
+  model_id: z.string(),
+  drone_id: z.string(),
+  confidence_threshold: z.number().min(0).max(1).default(0.5),
+  follow_distance: z.number().min(50).max(500).default(200),
+});
+
+export type StartTrackingRequest = z.infer<typeof StartTrackingRequestSchema>;
+
+export const TrackingStatusSchema = z.object({
+  is_active: z.boolean(),
+  model_id: z.string().optional(),
+  drone_id: z.string().optional(),
+  target_detected: z.boolean(),
+  target_position: BoundingBoxSchema.optional(),
+  follow_distance: z.number().optional(),
+  last_detection_time: z.string().datetime().optional(),
+  started_at: z.string().datetime().optional(),
+});
+
+export type TrackingStatus = z.infer<typeof TrackingStatusSchema>;
+
+// ========================================
+// Model API Types
+// ========================================
+
+export const TrainingParamsSchema = z.object({
+  epochs: z.number().min(1).max(1000).default(100),
+  batch_size: z.number().min(1).max(64).default(16),
+  learning_rate: z.number().min(0.00001).max(1).default(0.001),
+  validation_split: z.number().min(0.1).max(0.5).default(0.2),
+});
+
+export type TrainingParams = z.infer<typeof TrainingParamsSchema>;
+
+export const ModelSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  dataset_id: z.string(),
+  model_type: z.enum(['yolo', 'ssd', 'faster_rcnn']),
+  status: z.enum(['training', 'completed', 'failed']),
+  accuracy: z.number().min(0).max(1).optional(),
+  file_path: z.string().optional(),
+  created_at: z.string().datetime(),
+  trained_at: z.string().datetime().optional(),
+});
+
+export type Model = z.infer<typeof ModelSchema>;
+
+export const TrainModelRequestSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional(),
+  dataset_id: z.string(),
+  model_type: z.enum(['yolo', 'ssd', 'faster_rcnn']).default('yolo'),
+  training_params: TrainingParamsSchema.optional(),
+});
+
+export type TrainModelRequest = z.infer<typeof TrainModelRequestSchema>;
+
+export const TrainingJobSchema = z.object({
+  id: z.string(),
+  model_name: z.string(),
+  dataset_id: z.string(),
+  status: z.enum(['queued', 'running', 'completed', 'failed', 'cancelled']),
+  progress: z.number().min(0).max(100),
+  current_epoch: z.number().min(0),
+  total_epochs: z.number().min(1),
+  loss: z.number().min(0).optional(),
+  accuracy: z.number().min(0).max(1).optional(),
+  estimated_remaining_time: z.number().min(0),
+  started_at: z.string().datetime(),
+  completed_at: z.string().datetime().optional(),
+  error_message: z.string().optional(),
+});
+
+export type TrainingJob = z.infer<typeof TrainingJobSchema>;
+
+// ========================================
+// Dashboard API Types
+// ========================================
+
+export const SystemStatusSchema = z.object({
+  cpu_usage: z.number().min(0).max(100),
+  memory_usage: z.number().min(0).max(100),
+  disk_usage: z.number().min(0).max(100),
+  temperature: z.number(),
+  connected_drones: z.number().min(0),
+  active_tracking: z.number().min(0),
+  running_training_jobs: z.number().min(0),
+  uptime: z.number().min(0),
+  last_updated: z.string().datetime(),
+});
+
+export type SystemStatus = z.infer<typeof SystemStatusSchema>;
+
+// ========================================
+// API Response Types
+// ========================================
+
+export const ScanDronesResponseSchema = z.object({
+  message: z.string(),
+  found: z.number().min(0),
+});
+
+export type ScanDronesResponse = z.infer<typeof ScanDronesResponseSchema>;
+
+export const HealthCheckResponseSchema = z.object({
+  status: z.string(),
+  timestamp: z.string().datetime(),
+});
+
+export type HealthCheckResponse = z.infer<typeof HealthCheckResponseSchema>;
+
+export const CommandResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+export type CommandResponse = z.infer<typeof CommandResponseSchema>;
+
+// ========================================
+// API Error Codes
+// ========================================
+
+export const API_ERROR_CODES = {
+  INVALID_REQUEST: 'INVALID_REQUEST',
+  INVALID_COMMAND: 'INVALID_COMMAND',
+  DRONE_NOT_FOUND: 'DRONE_NOT_FOUND',
+  DRONE_NOT_READY: 'DRONE_NOT_READY',
+  DRONE_ALREADY_CONNECTED: 'DRONE_ALREADY_CONNECTED',
+  DRONE_UNAVAILABLE: 'DRONE_UNAVAILABLE',
+  DATASET_NOT_FOUND: 'DATASET_NOT_FOUND',
+  MODEL_NOT_FOUND: 'MODEL_NOT_FOUND',
+  JOB_NOT_FOUND: 'JOB_NOT_FOUND',
+  TRACKING_ALREADY_ACTIVE: 'TRACKING_ALREADY_ACTIVE',
+  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+} as const;
+
+export type ApiErrorCode = typeof API_ERROR_CODES[keyof typeof API_ERROR_CODES];
+
+// ========================================
+// Utility Types
+// ========================================
+
+export type ApiResponse<T> = {
+  data: T;
+  status: number;
+  statusText: string;
+};
+
+export type PaginatedResponse<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  has_next: boolean;
+  has_prev: boolean;
+};
+
+export type FileUploadFormData = {
+  file: File;
+  label?: string;
+};
+
+// ========================================
+// API Client Configuration
+// ========================================
+
+export const DefaultBackendConfigSchema = z.object({
+  baseURL: z.string().url().default('http://localhost:8000'),
+  timeout: z.number().positive().default(30000),
+  retries: z.number().min(0).max(5).default(3),
+  retryDelay: z.number().positive().default(1000),
+});
+
+export type DefaultBackendConfig = z.infer<typeof DefaultBackendConfigSchema>;


### PR DESCRIPTION
## サマリ

MCP Node.js Migration Phase 3の実装を完了しました。バックエンドAPI連携機能を包括的に実装し、テスト機能も強化しました。

## 主要な変更

- 拡張API型定義実装 (src/types/api_types.ts)
- BackendClient機能大幅拡張 (src/clients/BackendClient.ts)
- 包括的接続テストスクリプト追加 (src/test/connection-test.ts)
- README更新・ドキュメント整備
- package.json更新

## テスト計画

- [ ] `npm install`で依存関係をインストール
- [ ] `npm run build`でTypeScriptコンパイル確認
- [ ] `npm run test`で単体テスト実行
- [ ] `npm run lint`でコード品質チェック
- [ ] `npm run test:connection`でバックエンド連携テスト

🤖 [Claude Code](https://claude.ai/code) により作成