### PR TITLE
Phase A: ドキュメント統一更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ npx mcp-drone-server-nodejs
 ```bash
 cd mcp-server
 pip install -r requirements.txt
-python start_mcp_server.py
+python start_mcp_server_unified.py
 ```
 
 ## Docker環境

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ npm start
 npx mcp-drone-server-nodejs
 ```
 
-**Python版**：
+**Python版（レガシー）**：
 ```bash
 cd mcp-server
 pip install -r requirements.txt
-python start_mcp_server.py
+python start_mcp_server_unified.py
 ```
 
 ### Docker環境での起動

--- a/backend/docs/plan/PHASE3_ENHANCED_README.md
+++ b/backend/docs/plan/PHASE3_ENHANCED_README.md
@@ -432,9 +432,18 @@ python start_api_server.py
 ```
 
 ### 強化機能付きMCPサーバー起動
+
+**Node.js版（推奨）**:
+```bash
+cd mcp-server-nodejs
+npm run build
+npm start
+```
+
+**Python版（レガシー）**:
 ```bash
 cd mcp-server
-python start_mcp_server.py --enhanced
+python start_mcp_server_unified.py --enhanced
 ```
 
 ## 🌟 使用例・シナリオ

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -32,10 +32,25 @@ curl http://localhost:8000/health
 ```
 
 ### 1.2 MCPサーバー起動 (Windows PC)
+
+**Node.js版（推奨）**:
+```bash
+# Windows PCで実行
+cd C:\path\to\mfg_drone_by_claudecode\mcp-server-nodejs
+npm install
+npm run build
+npm start
+
+# 起動確認
+curl http://localhost:8001/mcp/system/health
+# 応答: {"status": "healthy"}
+```
+
+**Python版（レガシー）**:
 ```bash
 # Windows PCで実行
 cd C:\path\to\mfg_drone_by_claudecode\mcp-server
-python start_mcp_server.py
+python start_mcp_server_unified.py
 
 # 起動確認
 curl http://localhost:8001/mcp/system/health

--- a/mcp-server/PHASE1_ANALYSIS.md
+++ b/mcp-server/PHASE1_ANALYSIS.md
@@ -32,7 +32,7 @@ MCPサーバーサブプロジェクトからFastAPIサーバー機能を除去�
   - ビジョン分析機能
 
 #### 起動スクリプト
-- **`start_mcp_server.py`** - FastAPI起動スクリプト（uvicorn使用）
+- **`start_mcp_server_unified.py`** - FastAPI起動スクリプト（uvicorn使用）
 - **`start_phase4_mcp_server.py`** - Phase 4 FastAPI起動
 - **`start_phase5_mcp_server.py`** - Phase 5 FastAPI起動
 
@@ -104,7 +104,7 @@ mecab-python3==1.0.6  # 日本語処理
 - [ ] `src/enhanced_main.py` (800行以上) - 拡張FastAPIアプリケーション
 - [ ] `src/api/` ディレクトリ全体
   - `src/api/phase4_vision.py` - Vision APIルーター
-- [ ] `start_mcp_server.py` - FastAPI起動スクリプト
+- [ ] `start_mcp_server_unified.py` - FastAPI起動スクリプト
 - [ ] `start_phase4_mcp_server.py` - Phase 4起動スクリプト
 - [ ] `start_phase5_mcp_server.py` - Phase 5起動スクリプト
 
@@ -125,7 +125,7 @@ mecab-python3==1.0.6  # 日本語処理
 - **MCPサーバー**: `src/mcp_main.py` (Model Context Protocol実装)
 - **バックエンド通信**: `src/core/backend_client.py` (HTTP APIクライアント)
 - **自然言語処理**: `src/core/nlp_engine.py` (日本語対応)
-- **起動スクリプト**: `start_mcp_server.py` (シンプルなMCP起動)
+- **起動スクリプト**: `start_mcp_server_unified.py` (シンプルなMCP起動)
 
 ### 保持される機能
 - ドローン制御コマンド（接続、離陸、着陸、移動、回転、撮影）


### PR DESCRIPTION
Issue #114 に対応して、ドキュメント内のstart_mcp_server.py参照を修正しました。

## 修正内容
- README.md、CLAUDE.md、docs/quick_start.md、backend/docs/plan/PHASE3_ENHANCED_README.mdの参照を修正
- start_mcp_server.py → start_mcp_server_unified.py に更新
- Node.js版を推奨版として明示、Python版をレガシーとして明記
- ドキュメント間の一貫性を確保

## 検証結果
- 対象ファイル4件すべて修正完了
- 全ての参照が正しいファイル名に更新済み
- ドキュメントの一貫性を確保

 [Claude Code](https://claude.ai/code)による作業