### PR TITLE
feat: Node.js MCPサーバの統合テスト・スイートの更新

### DIFF
--- a/api_spec_validator.py
+++ b/api_spec_validator.py
@@ -61,7 +61,7 @@ class ApiSpecValidationReport:
 class ApiSpecValidator:
     """API仕様適合性検証ツール"""
     
-    def __init__(self, spec_file: Path, base_url: str = "http://localhost:8001"):
+    def __init__(self, spec_file: Path, base_url: str = "http://localhost:3001"):
         self.spec_file = spec_file
         self.base_url = base_url
         self.spec_data = None

--- a/phase9_mcp_migration_tests.py
+++ b/phase9_mcp_migration_tests.py
@@ -87,7 +87,7 @@ class MCPMigrationTestSuite:
         
         # サーバーURL設定
         self.python_server_url = "http://localhost:8001"
-        self.nodejs_server_url = "http://localhost:8002"
+        self.nodejs_server_url = "http://localhost:3001"
         
         # テスト用データ
         self.test_commands = [

--- a/phase9_performance_benchmark.py
+++ b/phase9_performance_benchmark.py
@@ -71,7 +71,7 @@ class MCPPerformanceBenchmark:
         
         # サーバーURL設定
         self.python_server_url = "http://localhost:8001"
-        self.nodejs_server_url = "http://localhost:8002"
+        self.nodejs_server_url = "http://localhost:3001"
         
         # ベンチマーク設定
         self.benchmark_config = {

--- a/test_phase6_5_comprehensive.py
+++ b/test_phase6_5_comprehensive.py
@@ -94,7 +94,7 @@ class Phase6ComprehensiveTestSuite:
         self.test_cases = []
         
         # テスト対象URLs
-        self.mcp_server_url = "http://localhost:8001"
+        self.mcp_server_url = "http://localhost:3001"
         self.backend_api_url = "http://localhost:8000"
         self.frontend_url = "http://localhost:3000"
         


### PR DESCRIPTION
- test_phase6_5_comprehensive.py MCP サーバの URL を 8001 から 3001 に更新
- phase9_mcp_migration_tests.pyのNode.jsサーバのURLを8002から3001に更新
- 更新 phase9_performance_benchmark.py Node.js サーバの URL を 8002 から 3001 に変更
- api_spec_validator.py のデフォルトのベース URL を 8001 から 3001 に更新

これらの変更は、mcp-server-nodejs/src/types/index.tsで設定されているNode.js MCPサーバーのデフォルトポート(3001)にテストスイートを合わせます。

関連Issue #120