### PR TITLE
Phase E: クライアントライブラリのNode.js対応

### DIFF
--- a/client-libraries/README.md
+++ b/client-libraries/README.md
@@ -71,7 +71,7 @@ cd types && npm run build
 import { MCPClient } from 'mcp-drone-client';
 
 const client = new MCPClient({
-  baseURL: 'http://localhost:8001',
+  baseURL: 'http://localhost:3001',
   apiKey: 'your-api-key'
 });
 
@@ -94,7 +94,7 @@ from mcp_drone_client import MCPClient, MCPClientConfig, NaturalLanguageCommand
 
 async def main():
     config = MCPClientConfig(
-        base_url="http://localhost:8001",
+        base_url="http://localhost:3001",
         api_key="your-api-key"
     )
     
@@ -195,7 +195,7 @@ node test_all.js javascript python
 
 ### ネットワーク要件
 
-- **MCPサーバー**: ポート8001での通信
+- **MCPサーバー**: ポート3001での通信
 - **バックエンドAPI**: ポート8000での通信
 - **WebSocket**: リアルタイム通信用
 - **認証**: API Key または JWT Bearer Token

--- a/client-libraries/cli/README.md
+++ b/client-libraries/cli/README.md
@@ -50,7 +50,7 @@ mcp-drone configure
 ```
 
 設定項目：
-- MCPサーバーURL (デフォルト: http://localhost:8001)
+- MCPサーバーURL (デフォルト: http://localhost:3001)
 - API Key (オプション)
 - Bearer Token (オプション)
 - リクエストタイムアウト (デフォルト: 30000ms)
@@ -138,7 +138,7 @@ mcp-drone watch
 
 ### ネットワーク要件
 
-- **MCPサーバー**: ポート8001での通信
+- **MCPサーバー**: ポート3001での通信
 - **WebSocket**: リアルタイム通信用
 - **ファイアウォール**: localhost通信許可
 

--- a/client-libraries/cli/src/index.ts
+++ b/client-libraries/cli/src/index.ts
@@ -228,7 +228,7 @@ class ConfigManager {
       return yaml.parse(content);
     }
     return {
-      baseURL: 'http://localhost:8001',
+      baseURL: 'http://localhost:3001',
       timeout: 30000,
     };
   }

--- a/client-libraries/javascript/README.md
+++ b/client-libraries/javascript/README.md
@@ -46,7 +46,7 @@ import { MCPClient } from 'mcp-drone-client';
 
 // クライアント初期化
 const client = new MCPClient({
-  baseURL: 'http://localhost:8001',
+  baseURL: 'http://localhost:3001',
   apiKey: 'your-api-key', // または bearerToken
 });
 ```
@@ -208,7 +208,7 @@ try {
 
 ### ネットワーク要件
 
-- **MCPサーバー**: ポート8001での通信
+- **MCPサーバー**: ポート3001での通信
 - **WebSocket**: リアルタイム通信用
 - **CORS**: ブラウザ環境での通信許可
 
@@ -230,7 +230,7 @@ javascript/
 
 ```typescript
 interface MCPClientConfig {
-  baseURL: string;          // MCPサーバーURL
+  baseURL: string;          // MCPサーバーURL (例: http://localhost:3001)
   apiKey?: string;          // API Key認証
   bearerToken?: string;     // JWT Bearer Token認証
   timeout?: number;         // リクエストタイムアウト(ms、デフォルト: 30000)

--- a/client-libraries/javascript/src/index.test.ts
+++ b/client-libraries/javascript/src/index.test.ts
@@ -26,7 +26,7 @@ describe('MCPClient', () => {
     mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
     
     client = new MCPClient({
-      baseURL: 'http://localhost:8001',
+      baseURL: 'http://localhost:3001',
       apiKey: 'test-key'
     });
   });
@@ -35,7 +35,7 @@ describe('MCPClient', () => {
     it('should create instance with config', () => {
       expect(client).toBeInstanceOf(MCPClient);
       expect(mockedAxios.create).toHaveBeenCalledWith({
-        baseURL: 'http://localhost:8001',
+        baseURL: 'http://localhost:3001',
         timeout: 30000,
         headers: {
           'Content-Type': 'application/json',
@@ -46,13 +46,13 @@ describe('MCPClient', () => {
 
     it('should create instance with bearer token', () => {
       const clientWithToken = new MCPClient({
-        baseURL: 'http://localhost:8001',
+        baseURL: 'http://localhost:3001',
         bearerToken: 'test-token'
       });
       
       expect(clientWithToken).toBeInstanceOf(MCPClient);
       expect(mockedAxios.create).toHaveBeenCalledWith({
-        baseURL: 'http://localhost:8001',
+        baseURL: 'http://localhost:3001',
         timeout: 30000,
         headers: {
           'Content-Type': 'application/json',

--- a/client-libraries/python/README.md
+++ b/client-libraries/python/README.md
@@ -48,7 +48,7 @@ from mcp_drone_client import MCPClient, MCPClientConfig, NaturalLanguageCommand
 async def main():
     # クライアント設定
     config = MCPClientConfig(
-        base_url="http://localhost:8001",
+        base_url="http://localhost:3001",
         api_key="your-api-key",  # または bearer_token
         timeout=30.0,
     )
@@ -234,7 +234,7 @@ except Exception as e:
 
 ### ネットワーク要件
 
-- **MCPサーバー**: ポート8001での通信
+- **MCPサーバー**: ポート3001での通信
 - **WebSocket**: リアルタイム通信用
 - **SSL/TLS**: HTTPS通信対応
 
@@ -260,7 +260,7 @@ python/
 from mcp_drone_client.models import MCPClientConfig
 
 config = MCPClientConfig(
-    base_url="http://localhost:8001",      # MCPサーバーURL
+    base_url="http://localhost:3001",      # MCPサーバーURL
     api_key="your-api-key",                # API Key認証
     bearer_token="your-jwt-token",         # JWT Bearer Token認証
     timeout=30.0,                          # リクエストタイムアウト(秒)

--- a/client-libraries/python/tests/test_client.py
+++ b/client-libraries/python/tests/test_client.py
@@ -39,7 +39,7 @@ from mcp_drone_client.models import (
 def client_config():
     """Client configuration fixture"""
     return MCPClientConfig(
-        base_url="http://localhost:8001",
+        base_url="http://localhost:3001",
         api_key="test-api-key",
         timeout=30.0,
     )
@@ -59,13 +59,13 @@ class TestMCPClient:
     def test_create_client_convenience_function(self):
         """Test create_client convenience function"""
         client = create_client(
-            base_url="http://localhost:8001",
+            base_url="http://localhost:3001",
             api_key="test-key",
             timeout=60.0,
         )
         
         assert isinstance(client, MCPClient)
-        assert client.config.base_url == "http://localhost:8001"
+        assert client.config.base_url == "http://localhost:3001"
         assert client.config.api_key == "test-key"
         assert client.config.timeout == 60.0
     


### PR DESCRIPTION
Phase Eの作業を完了しました。

## 変更内容
- すべてのクライアントライブラリのデフォルト接続先をポート8001からポート3001に変更
- Node.js版MCPサーバーへの統一接続を実現
- ドキュメントの更新と一貫性の確保

## 影響範囲
- Pythonクライアントライブラリ
- JavaScriptクライアントライブラリ
- CLIツール
- メインREADMEドキュメント

Issue #122 

[Claude Code](https://claude.ai/code)より作成